### PR TITLE
Invalid inheritance

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="8"
+    errorLevel="7"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/MySql/Clause/PartitionClause.php
+++ b/src/MySql/Clause/PartitionClause.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\MySql\Clause;
 
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 
 trait PartitionClause
 {
     /**
-     * @var ListExpression
+     * @var ColumnListExpression
      */
     protected $partition;
 
@@ -19,7 +19,7 @@ trait PartitionClause
      */
     public function partition($partition)
     {
-        $this->partition = $this->partition ?? new ListExpression();
+        $this->partition = $this->partition ?? new ColumnListExpression();
         $this->partition->append($partition);
         $this->built = false;
         return $this;

--- a/src/MySql/Clause/RowAliasClause.php
+++ b/src/MySql/Clause/RowAliasClause.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\MySql\Clause;
 
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 
 trait RowAliasClause
 {
     protected ?string $rowAlias = null;
 
     /**
-     * @var ListExpression
+     * @var ColumnListExpression
      */
     protected $columnAliases;
 
@@ -23,7 +23,7 @@ trait RowAliasClause
     {
         $this->rowAlias = $rowAlias;
         if ($columnAliases !== null) {
-            $this->columnAliases = $this->columnAliases ?? new ListExpression();
+            $this->columnAliases = $this->columnAliases ?? new ColumnListExpression();
             $this->columnAliases->append($columnAliases);
         }
         $this->built = false;

--- a/src/MySql/DeleteStatement.php
+++ b/src/MySql/DeleteStatement.php
@@ -9,8 +9,8 @@ use AlephTools\SqlBuilder\MySql\Clause\PartitionClause;
 use AlephTools\SqlBuilder\Sql\AbstractDeleteStatement;
 use AlephTools\SqlBuilder\Sql\Clause\LimitClause;
 use AlephTools\SqlBuilder\Sql\Clause\OrderClause;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\FromExpression;
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\OrderExpression;
 use AlephTools\SqlBuilder\Sql\Expression\WhereExpression;
 use AlephTools\SqlBuilder\Sql\Expression\WithExpression;
@@ -28,7 +28,7 @@ class DeleteStatement extends AbstractDeleteStatement
         WithExpression $with = null,
         string $modifiers = null,
         FromExpression $from = null,
-        ListExpression $partition = null,
+        ColumnListExpression $partition = null,
         FromExpression $using = null,
         WhereExpression $where = null,
         OrderExpression $order = null,

--- a/src/MySql/InsertStatement.php
+++ b/src/MySql/InsertStatement.php
@@ -13,8 +13,8 @@ use AlephTools\SqlBuilder\Query;
 use AlephTools\SqlBuilder\Sql\AbstractInsertStatement;
 use AlephTools\SqlBuilder\Sql\Clause\AssignmentClause;
 use AlephTools\SqlBuilder\Sql\Expression\AssignmentExpression;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\FromExpression;
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\ValueListExpression;
 use AlephTools\SqlBuilder\StatementExecutor;
 
@@ -31,10 +31,10 @@ class InsertStatement extends AbstractInsertStatement
         StatementExecutor $db = null,
         string $modifiers = null,
         FromExpression $table = null,
-        ListExpression $partition = null,
-        ListExpression $columns = null,
+        ColumnListExpression $partition = null,
+        ColumnListExpression $columns = null,
         string $rowAlias = null,
-        ListExpression $columnAliases = null,
+        ColumnListExpression $columnAliases = null,
         ValueListExpression $values = null,
         Query $query = null,
         AssignmentExpression $assignment = null,

--- a/src/PostgreSql/Clause/ConflictClause.php
+++ b/src/PostgreSql/Clause/ConflictClause.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace AlephTools\SqlBuilder\PostgreSql\Clause;
 
 use AlephTools\SqlBuilder\Sql\Expression\AssignmentExpression;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\ConditionalExpression;
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
 
 trait ConflictClause
 {
     /**
-     * @var ListExpression
+     * @var ColumnListExpression
      */
     protected $indexColumn;
 
@@ -63,7 +63,7 @@ trait ConflictClause
      */
     public function onConflict($indexColumn = '', $indexPredicate = null)
     {
-        $this->indexColumn = $this->indexColumn ?? new ListExpression();
+        $this->indexColumn = $this->indexColumn ?? new ColumnListExpression();
         $this->indexColumn->append($indexColumn);
         if ($indexPredicate !== null) {
             if ($this->indexPredicate) {

--- a/src/PostgreSql/InsertStatement.php
+++ b/src/PostgreSql/InsertStatement.php
@@ -13,9 +13,9 @@ use AlephTools\SqlBuilder\Sql\Clause\ReturningClause;
 use AlephTools\SqlBuilder\Sql\Clause\WithClause;
 use AlephTools\SqlBuilder\Sql\Execution\DataFetching;
 use AlephTools\SqlBuilder\Sql\Expression\AssignmentExpression;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\ConditionalExpression;
 use AlephTools\SqlBuilder\Sql\Expression\FromExpression;
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\ReturningExpression;
 use AlephTools\SqlBuilder\Sql\Expression\ValueListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\WithExpression;
@@ -34,10 +34,10 @@ class InsertStatement extends AbstractInsertStatement
         StatementExecutor $db = null,
         WithExpression $with = null,
         FromExpression $table = null,
-        ListExpression $columns = null,
+        ColumnListExpression $columns = null,
         ValueListExpression $values = null,
         Query $query = null,
-        ListExpression $indexColumn = null,
+        ColumnListExpression $indexColumn = null,
         ConditionalExpression $indexPredicate = null,
         string $indexConstraint = null,
         AssignmentExpression $assignment = null,

--- a/src/Sql/AbstractInsertStatement.php
+++ b/src/Sql/AbstractInsertStatement.php
@@ -10,8 +10,8 @@ use AlephTools\SqlBuilder\Sql\Clause\ColumnsClause;
 use AlephTools\SqlBuilder\Sql\Clause\InsertClause;
 use AlephTools\SqlBuilder\Sql\Clause\QueryClause;
 use AlephTools\SqlBuilder\Sql\Clause\ValueListClause;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\FromExpression;
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
 use AlephTools\SqlBuilder\Sql\Expression\ValueListExpression;
 use AlephTools\SqlBuilder\StatementExecutor;
 
@@ -25,7 +25,7 @@ abstract class AbstractInsertStatement extends AbstractStatement implements Comm
     public function __construct(
         StatementExecutor $db = null,
         FromExpression $table = null,
-        ListExpression $columns = null,
+        ColumnListExpression $columns = null,
         ValueListExpression $values = null,
         Query $query = null
     ) {

--- a/src/Sql/Clause/ColumnsClause.php
+++ b/src/Sql/Clause/ColumnsClause.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\Sql\Clause;
 
-use AlephTools\SqlBuilder\Sql\Expression\ListExpression;
+use AlephTools\SqlBuilder\Sql\Expression\ColumnListExpression;
 
 trait ColumnsClause
 {
     /**
-     * @var ListExpression
+     * @var ColumnListExpression
      */
     protected $columns;
 
@@ -27,7 +27,7 @@ trait ColumnsClause
 
     protected function createColumnsExpression()
     {
-        return new ListExpression();
+        return new ColumnListExpression();
     }
 
     protected function buildColumns(): void

--- a/src/Sql/Expression/ColumnListExpression.php
+++ b/src/Sql/Expression/ColumnListExpression.php
@@ -6,7 +6,7 @@ namespace AlephTools\SqlBuilder\Sql\Expression;
 
 use AlephTools\SqlBuilder\Query;
 
-class ListExpression extends AbstractExpression
+class ColumnListExpression extends AbstractExpression
 {
     public function __construct($column = null, $alias = null)
     {

--- a/src/Sql/Expression/FromExpression.php
+++ b/src/Sql/Expression/FromExpression.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\Sql\Expression;
 
-class FromExpression extends ListExpression
+use AlephTools\SqlBuilder\Query;
+
+class FromExpression extends AbstractExpression
 {
     public function __construct($table = null, $alias = null)
     {
-        parent::__construct($table, $alias);
+        if ($table !== null || $alias !== null) {
+            $this->append($table, $alias);
+        }
     }
 
     /**
@@ -18,6 +22,66 @@ class FromExpression extends ListExpression
      */
     public function append($table, $alias = null)
     {
-        return parent::append($table, $alias);
+        if ($this->sql !== '') {
+            $this->sql .= ', ';
+        }
+        $this->sql .= $this->convertNameToString($this->mapToExpression($table, $alias));
+        return $this;
+    }
+
+    protected function mapToExpression($table, $alias)
+    {
+        if ($alias === null) {
+            return $table;
+        }
+        if (is_scalar($alias)) {
+            $expression = [$alias => $table];
+        } else {
+            $expression = [[$alias, $table]];
+        }
+        return $expression;
+    }
+
+    protected function convertNameToString($expression): string
+    {
+        if ($expression === null) {
+            return $this->nullToString();
+        }
+        if ($expression instanceof RawExpression) {
+            return $this->rawExpressionToString($expression);
+        }
+        if ($expression instanceof Query) {
+            return $this->queryToString($expression);
+        }
+        if ($expression instanceof ValueListExpression) {
+            return $this->valueListExpressionToString($expression);
+        }
+        if (is_array($expression)) {
+            return $this->arrayToString($expression);
+        }
+        return (string)$expression;
+    }
+
+    protected function valueListExpressionToString(ValueListExpression $expression): string
+    {
+        $this->addParams($expression->getParams());
+        return "(VALUES $expression)";
+    }
+
+    protected function arrayToString(array $expression): string
+    {
+        $list = [];
+        foreach ($expression as $alias => $column) {
+            if (is_numeric($alias)) {
+                if (is_array($column) && \count($column) === 2) {
+                    [$alias, $column] = $column;
+                } else {
+                    $alias = null;
+                }
+            }
+            $alias = $alias === null ? '' : $this->convertNameToString($alias);
+            $list[] = $this->convertNameToString($column) . ($alias === '' ? '' : " $alias");
+        }
+        return implode(', ', $list);
     }
 }

--- a/src/Sql/Expression/JoinExpression.php
+++ b/src/Sql/Expression/JoinExpression.php
@@ -33,7 +33,7 @@ class JoinExpression extends AbstractExpression
 
     protected function convertTableToString($table, $alias): string
     {
-        $tb = new ListExpression($table, $alias);
+        $tb = new ColumnListExpression($table, $alias);
         $this->addParams($tb->getParams());
         if (is_array($table) && \count($table) > 1) {
             return "($tb)";
@@ -50,7 +50,7 @@ class JoinExpression extends AbstractExpression
             $conditions = new ConditionalExpression($condition);
             $this->sql .= " ON $conditions";
         } else {
-            $conditions = new ListExpression($condition);
+            $conditions = new ColumnListExpression($condition);
             $this->sql .= " USING ($conditions)";
         }
         $this->addParams($conditions->getParams());

--- a/src/Sql/Expression/ReturningExpression.php
+++ b/src/Sql/Expression/ReturningExpression.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\Sql\Expression;
 
-class ReturningExpression extends ListExpression
+class ReturningExpression extends ColumnListExpression
 {
 }

--- a/src/Sql/Expression/SelectExpression.php
+++ b/src/Sql/Expression/SelectExpression.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\Sql\Expression;
 
-class SelectExpression extends ListExpression
+class SelectExpression extends ColumnListExpression
 {
 }


### PR DESCRIPTION
It removes incorrect inheritance from:

```
FromExpression($table, $alias)
OrderExpression($column, $order)
```

to base expression:

```
ListExpression($column, $alias)
```

and renames list expression to list of columns: 

```
ColumnListExpression($column, $alias)
```