### PR TITLE
Revert Psalm level

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="1"
+    errorLevel="2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    reportMixedIssues="false"
 >
 
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+
+    <issueHandlers>
+        <PossiblyNullOperand errorLevel="error"/>
+        <LessSpecificReturnType errorLevel="error"/>
+        <RedundantIdentityWithTrue errorLevel="error"/>
+    </issueHandlers>
 
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
The 1st level in Psalm means totally typed mode without `mixed` pseudo-type.

So setting 1st level with suppressing its errors by `reportMixedIssues` option is useless.