### PR TITLE
Simplify type annotations

### DIFF
--- a/src/StatementExecutor.php
+++ b/src/StatementExecutor.php
@@ -30,8 +30,7 @@ interface StatementExecutor
      *
      * @param string $sql The SQL statement.
      * @param array $params The parameters to be bound to the SQL statement.
-     * @return array[]
-     * @psalm-return list<array<string,mixed>>
+     * @return list<array<string,mixed>>
      */
     public function rows(string $sql, array $params): array;
 
@@ -40,7 +39,7 @@ interface StatementExecutor
      *
      * @param string $sql The SQL statement.
      * @param array $params The parameters to be bound to the SQL statement.
-     * @psalm-return array<string,mixed>
+     * @return array<string,mixed>
      */
     public function row(string $sql, array $params): array;
 
@@ -49,7 +48,7 @@ interface StatementExecutor
      *
      * @param string $sql The SQL statement.
      * @param array $params The parameters to be bound to the SQL statement.
-     * @psalm-return list<mixed>
+     * @return list<mixed>
      */
     public function column(string $sql, array $params): array;
 

--- a/tests/PostgreSql/SelectStatementTest.php
+++ b/tests/PostgreSql/SelectStatementTest.php
@@ -2029,7 +2029,7 @@ class SelectStatementTest extends TestCase
     }
 
     /**
-     * @psalm-return MockObject&StatementExecutor
+     * @return MockObject&StatementExecutor
      */
     private function getExecutorMock()
     {


### PR DESCRIPTION
It is not necessary to use `psalm-` prefixed tags for [general cases](https://phpstan.org/writing-php-code/phpdoc-types).