### PR TITLE
Pass executor into methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ echo $st->toSql();
 // ['p1' => 'ADMIN', 'p2' => 'RESELLER', 'p3' => 5]
 print_r($st->getParams());
 
-// Executes statement if StatementExecutor is defined, otherwise an exception is thrown
-$rows = $st->rows();
+// Executes statement by StatementExecutor
+$rows = $st->rows($db);
 
 ```
 

--- a/src/MySql/DeleteStatement.php
+++ b/src/MySql/DeleteStatement.php
@@ -22,7 +22,7 @@ class DeleteStatement extends AbstractDeleteStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->with = $this->with ? clone $this->with : null;
         $copy->modifiers = $this->modifiers;
         $copy->from = $this->from ? clone $this->from : null;

--- a/src/MySql/InsertStatement.php
+++ b/src/MySql/InsertStatement.php
@@ -26,7 +26,7 @@ class InsertStatement extends AbstractInsertStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->modifiers = $this->modifiers;
         $copy->table = $this->table ? clone $this->table : null;
         $copy->partition = $this->partition ? clone $this->partition : null;

--- a/src/MySql/UpdateStatement.php
+++ b/src/MySql/UpdateStatement.php
@@ -20,7 +20,7 @@ class UpdateStatement extends AbstractUpdateStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->with = $this->with ? clone $this->with : null;
         $copy->modifiers = $this->modifiers;
         $copy->table = $this->table ? clone $this->table : null;

--- a/src/MySql/ValuesStatement.php
+++ b/src/MySql/ValuesStatement.php
@@ -18,7 +18,7 @@ class ValuesStatement extends AbstractValuesStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->values = $this->values ? clone $this->values : null;
         $copy->order = $this->order ? clone $this->order : null;
         $copy->limit = $this->limit;

--- a/src/PostgreSql/DeleteStatement.php
+++ b/src/PostgreSql/DeleteStatement.php
@@ -20,7 +20,7 @@ class DeleteStatement extends AbstractDeleteStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->with = $this->with ? clone $this->with : null;
         $copy->from = $this->from ? clone $this->from : null;
         $copy->only = $this->only;

--- a/src/PostgreSql/InsertStatement.php
+++ b/src/PostgreSql/InsertStatement.php
@@ -26,7 +26,7 @@ class InsertStatement extends AbstractInsertStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->with = $this->with ? clone $this->with : null;
         $copy->table = $this->table ? clone $this->table : null;
         $copy->columns = $this->columns ? clone $this->columns : null;

--- a/src/PostgreSql/UpdateStatement.php
+++ b/src/PostgreSql/UpdateStatement.php
@@ -22,7 +22,7 @@ class UpdateStatement extends AbstractUpdateStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->with = $this->with ? clone $this->with : null;
         $copy->table = $this->table ? clone $this->table : null;
         $copy->only = $this->only;

--- a/src/PostgreSql/ValuesStatement.php
+++ b/src/PostgreSql/ValuesStatement.php
@@ -22,7 +22,7 @@ class ValuesStatement extends AbstractValuesStatement
      */
     public function copy()
     {
-        $copy = new static($this->db);
+        $copy = new static();
         $copy->values = $this->values ? clone $this->values : null;
         $copy->order = $this->order ? clone $this->order : null;
         $copy->limit = $this->limit;

--- a/src/Sql/AbstractInsertStatement.php
+++ b/src/Sql/AbstractInsertStatement.php
@@ -9,6 +9,7 @@ use AlephTools\SqlBuilder\Sql\Clause\ColumnsClause;
 use AlephTools\SqlBuilder\Sql\Clause\InsertClause;
 use AlephTools\SqlBuilder\Sql\Clause\QueryClause;
 use AlephTools\SqlBuilder\Sql\Clause\ValueListClause;
+use AlephTools\SqlBuilder\StatementExecutor;
 
 abstract class AbstractInsertStatement extends AbstractStatement implements Command
 {
@@ -23,8 +24,8 @@ abstract class AbstractInsertStatement extends AbstractStatement implements Comm
      * @param string|null $sequence Name of the sequence object from which the ID should be returned.
      * @return mixed Returns the ID of the last inserted row or sequence value.
      */
-    public function exec(string $sequence = null)
+    public function exec(StatementExecutor $db, string $sequence = null)
     {
-        return $this->db()->insert($this->toSql(), $this->getParams(), $sequence);
+        return $db->insert($this->toSql(), $this->getParams(), $sequence);
     }
 }

--- a/src/Sql/AbstractStatement.php
+++ b/src/Sql/AbstractStatement.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace AlephTools\SqlBuilder\Sql;
 
 use AlephTools\SqlBuilder\Statement;
-use AlephTools\SqlBuilder\StatementExecutor;
-use RuntimeException;
 
 abstract class AbstractStatement implements Statement
 {
-    protected ?StatementExecutor $db;
     protected string $sql = '';
     protected array $params = [];
 
@@ -19,9 +16,8 @@ abstract class AbstractStatement implements Statement
      */
     protected bool $built = false;
 
-    final public function __construct(StatementExecutor $db = null)
+    final public function __construct()
     {
-        $this->db = $db;
     }
 
     /**
@@ -30,11 +26,6 @@ abstract class AbstractStatement implements Statement
     abstract public function copy();
 
     abstract public function clean(): void;
-
-    public function getStatementExecutor(): ?StatementExecutor
-    {
-        return $this->db;
-    }
 
     /**
      * @return static
@@ -66,20 +57,5 @@ abstract class AbstractStatement implements Statement
     public function __toString(): string
     {
         return $this->toSql();
-    }
-
-    protected function db(): StatementExecutor
-    {
-        $this->validateAndBuild();
-        /** @var StatementExecutor */
-        return $this->db;
-    }
-
-    protected function validateAndBuild(): void
-    {
-        if ($this->db === null) {
-            throw new RuntimeException('The statement executor must not be null.');
-        }
-        $this->build();
     }
 }

--- a/src/Sql/Execution/DataFetching.php
+++ b/src/Sql/Execution/DataFetching.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\Sql\Execution;
 
+use AlephTools\SqlBuilder\StatementExecutor;
 use RuntimeException;
 
 trait DataFetching
 {
-    public function rows(): array
+    public function rows(StatementExecutor $db): array
     {
-        return $this->db()->rows($this->toSql(), $this->getParams());
+        return $db->rows($this->toSql(), $this->getParams());
     }
 
-    public function pairs(string $key = ''): array
+    public function pairs(StatementExecutor $db, string $key = ''): array
     {
-        $rows = $this->rows();
+        $rows = $this->rows($db);
         if ($rows && $key !== '' && !array_key_exists($key, $rows[0])) {
             throw new RuntimeException("Key \"$key\" is not found in the row set.");
         }
@@ -37,9 +38,9 @@ trait DataFetching
         return $result;
     }
 
-    public function rowsByKey(string $key, bool $removeKeyFromRow = false): array
+    public function rowsByKey(StatementExecutor $db, string $key, bool $removeKeyFromRow = false): array
     {
-        $rows = $this->rows();
+        $rows = $this->rows($db);
         if ($rows && !array_key_exists($key, $rows[0])) {
             throw new RuntimeException("Key \"$key\" is not found in the row set.");
         }
@@ -58,9 +59,9 @@ trait DataFetching
         return $result;
     }
 
-    public function rowsByGroup(string $key, bool $removeKeyFromRow = false): array
+    public function rowsByGroup(StatementExecutor $db, string $key, bool $removeKeyFromRow = false): array
     {
-        $rows = $this->rows();
+        $rows = $this->rows($db);
         if ($rows && !array_key_exists($key, $rows[0])) {
             throw new RuntimeException("Key \"$key\" is not found in the row set.");
         }
@@ -79,21 +80,21 @@ trait DataFetching
         return $result;
     }
 
-    public function row(): array
+    public function row(StatementExecutor $db): array
     {
-        return $this->db()->row($this->toSql(), $this->getParams());
+        return $db->row($this->toSql(), $this->getParams());
     }
 
-    public function column(): array
+    public function column(StatementExecutor $db): array
     {
-        return $this->db()->column($this->toSql(), $this->getParams());
+        return $db->column($this->toSql(), $this->getParams());
     }
 
     /**
      * @return mixed
      */
-    public function scalar()
+    public function scalar(StatementExecutor $db)
     {
-        return $this->db()->scalar($this->toSql(), $this->getParams());
+        return $db->scalar($this->toSql(), $this->getParams());
     }
 }

--- a/src/Sql/Execution/StatementExecution.php
+++ b/src/Sql/Execution/StatementExecution.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace AlephTools\SqlBuilder\Sql\Execution;
 
+use AlephTools\SqlBuilder\StatementExecutor;
+
 trait StatementExecution
 {
     /**
      * Executes this command.
      */
-    public function exec(): int
+    public function exec(StatementExecutor $db): int
     {
-        return $this->db()->execute($this->toSql(), $this->getParams());
+        return $db->execute($this->toSql(), $this->getParams());
     }
 }

--- a/tests/PostgreSql/SelectStatementTest.php
+++ b/tests/PostgreSql/SelectStatementTest.php
@@ -1491,19 +1491,6 @@ class SelectStatementTest extends TestCase
     /**
      * @test
      */
-    public function validateExecutorInstance(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The statement executor must not be null.');
-
-        (new SelectStatement())
-            ->from('tb')
-            ->rows();
-    }
-
-    /**
-     * @test
-     */
     public function scalar(): void
     {
         $executor = $this->getExecutorMock();
@@ -1514,12 +1501,12 @@ class SelectStatementTest extends TestCase
             return 7;
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5);
 
-        self::assertSame(7, $st->scalar());
+        self::assertSame(7, $st->scalar($executor));
     }
 
     /**
@@ -1535,12 +1522,12 @@ class SelectStatementTest extends TestCase
             return 7;
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5);
 
-        self::assertSame(7, $st->scalar('c1'));
+        self::assertSame(7, $st->scalar($executor, 'c1'));
     }
 
     /**
@@ -1556,14 +1543,14 @@ class SelectStatementTest extends TestCase
             return 7;
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5)
             ->groupBy('c2')
             ->limit(10);
 
-        self::assertSame(7, $st->count());
+        self::assertSame(7, $st->count($executor));
     }
 
     /**
@@ -1579,14 +1566,14 @@ class SelectStatementTest extends TestCase
             return 7;
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5)
             ->groupBy('c2')
             ->limit(10);
 
-        self::assertSame(7, $st->countWithNonConditionalClauses());
+        self::assertSame(7, $st->countWithNonConditionalClauses($executor));
     }
 
     /**
@@ -1602,14 +1589,14 @@ class SelectStatementTest extends TestCase
             return 7;
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5)
             ->groupBy('c2')
             ->limit(10);
 
-        self::assertSame(7, $st->count('c4'));
+        self::assertSame(7, $st->count($executor, 'c4'));
     }
 
     /**
@@ -1625,14 +1612,14 @@ class SelectStatementTest extends TestCase
             return 7;
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5)
             ->groupBy('c2')
             ->limit(10);
 
-        self::assertSame(7, $st->countWithNonConditionalClauses('c4'));
+        self::assertSame(7, $st->countWithNonConditionalClauses($executor, 'c4'));
     }
 
     /**
@@ -1648,12 +1635,12 @@ class SelectStatementTest extends TestCase
             return [7];
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5);
 
-        self::assertSame([7], $st->column());
+        self::assertSame([7], $st->column($executor));
     }
 
     /**
@@ -1669,12 +1656,12 @@ class SelectStatementTest extends TestCase
             return [7];
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5);
 
-        self::assertSame([7], $st->column('c1'));
+        self::assertSame([7], $st->column($executor, 'c1'));
     }
 
     /**
@@ -1690,12 +1677,12 @@ class SelectStatementTest extends TestCase
             return [7];
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5);
 
-        self::assertSame([7], $st->row());
+        self::assertSame([7], $st->row($executor));
     }
 
     /**
@@ -1711,12 +1698,12 @@ class SelectStatementTest extends TestCase
             return [[7]];
         });
 
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->from('tb')
             ->select('c1, c2')
             ->where('c3', '=', 5);
 
-        self::assertSame([[7]], $st->rows());
+        self::assertSame([[7]], $st->rows($executor));
     }
 
     /**
@@ -1724,10 +1711,12 @@ class SelectStatementTest extends TestCase
      */
     public function pairsWithNonExistentKey(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Key "c4" is not found in the row set.');
 
-        $this->getSelectStatementMock()->pairs('c4');
+        (new SelectStatement())->pairs($executor, 'c4');
     }
 
     /**
@@ -1735,24 +1724,26 @@ class SelectStatementTest extends TestCase
      */
     public function pairs(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         self::assertSame(
             ['v1' => 'v2', 'v3' => 'v4', 'v5' => 'v6'],
-            $this->getSelectStatementMock()->pairs()
+            (new SelectStatement())->pairs($executor)
         );
 
         self::assertSame(
             ['v1' => 'v2', 'v3' => 'v4', 'v5' => 'v6'],
-            $this->getSelectStatementMock()->pairs('c1')
+            (new SelectStatement())->pairs($executor, 'c1')
         );
 
         self::assertSame(
             ['v2' => 'v1', 'v4' => 'v3', 'v6' => 'v5'],
-            $this->getSelectStatementMock()->pairs('c2')
+            (new SelectStatement())->pairs($executor, 'c2')
         );
 
         self::assertSame(
             ['a' => 'v1', 'b' => 'v5'],
-            $this->getSelectStatementMock()->pairs('c3')
+            (new SelectStatement())->pairs($executor, 'c3')
         );
     }
 
@@ -1761,10 +1752,12 @@ class SelectStatementTest extends TestCase
      */
     public function rowsByNonExistentKey(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Key "c4" is not found in the row set.');
 
-        $this->getSelectStatementMock()->rowsByKey('c4');
+        (new SelectStatement())->rowsByKey($executor, 'c4');
     }
 
     /**
@@ -1772,13 +1765,15 @@ class SelectStatementTest extends TestCase
      */
     public function rowsByKeyWithKey(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         self::assertSame(
             [
                 'v2' => ['c1' => 'v1', 'c2' => 'v2', 'c3' => 'a'],
                 'v4' => ['c1' => 'v3', 'c2' => 'v4', 'c3' => 'b'],
                 'v6' => ['c1' => 'v5', 'c2' => 'v6', 'c3' => 'b'],
             ],
-            $this->getSelectStatementMock()->rowsByKey('c2')
+            (new SelectStatement())->rowsByKey($executor, 'c2')
         );
 
         self::assertSame(
@@ -1786,7 +1781,7 @@ class SelectStatementTest extends TestCase
                 'a' => ['c1' => 'v1', 'c2' => 'v2', 'c3' => 'a'],
                 'b' => ['c1' => 'v5', 'c2' => 'v6', 'c3' => 'b'],
             ],
-            $this->getSelectStatementMock()->rowsByKey('c3')
+            (new SelectStatement())->rowsByKey($executor, 'c3')
         );
     }
 
@@ -1795,13 +1790,15 @@ class SelectStatementTest extends TestCase
      */
     public function rowsByKeyWithoutKey(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         self::assertSame(
             [
                 'v1' => ['c2' => 'v2', 'c3' => 'a'],
                 'v3' => ['c2' => 'v4', 'c3' => 'b'],
                 'v5' => ['c2' => 'v6', 'c3' => 'b'],
             ],
-            $this->getSelectStatementMock()->rowsByKey('c1', true)
+            (new SelectStatement())->rowsByKey($executor, 'c1', true)
         );
 
         self::assertSame(
@@ -1809,7 +1806,7 @@ class SelectStatementTest extends TestCase
                 'a' => ['c1' => 'v1', 'c2' => 'v2'],
                 'b' => ['c1' => 'v5', 'c2' => 'v6'],
             ],
-            $this->getSelectStatementMock()->rowsByKey('c3', true)
+            (new SelectStatement())->rowsByKey($executor, 'c3', true)
         );
     }
 
@@ -1818,10 +1815,12 @@ class SelectStatementTest extends TestCase
      */
     public function rowsByGroupWithNonExistentKey(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Key "c4" is not found in the row set.');
 
-        $this->getSelectStatementMock()->rowsByGroup('c4');
+        (new SelectStatement())->rowsByGroup($executor, 'c4');
     }
 
     /**
@@ -1829,6 +1828,8 @@ class SelectStatementTest extends TestCase
      */
     public function rowsByGroupWithKey(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         self::assertSame(
             [
                 'v2' => [
@@ -1841,7 +1842,7 @@ class SelectStatementTest extends TestCase
                     ['c1' => 'v5', 'c2' => 'v6', 'c3' => 'b'],
                 ],
             ],
-            $this->getSelectStatementMock()->rowsByGroup('c2')
+            (new SelectStatement())->rowsByGroup($executor, 'c2')
         );
 
         self::assertSame(
@@ -1854,7 +1855,7 @@ class SelectStatementTest extends TestCase
                     ['c1' => 'v5', 'c2' => 'v6', 'c3' => 'b'],
                 ],
             ],
-            $this->getSelectStatementMock()->rowsByGroup('c3')
+            (new SelectStatement())->rowsByGroup($executor, 'c3')
         );
     }
 
@@ -1863,6 +1864,8 @@ class SelectStatementTest extends TestCase
      */
     public function rowsByGroupWithoutKey(): void
     {
+        $executor = $this->getSelectStatementExecutorMock();
+
         self::assertSame(
             [
                 'v2' => [
@@ -1875,7 +1878,7 @@ class SelectStatementTest extends TestCase
                     ['c1' => 'v5', 'c3' => 'b'],
                 ],
             ],
-            $this->getSelectStatementMock()->rowsByGroup('c2', true)
+            (new SelectStatement())->rowsByGroup($executor, 'c2', true)
         );
 
         self::assertSame(
@@ -1888,7 +1891,7 @@ class SelectStatementTest extends TestCase
                     ['c1' => 'v5', 'c2' => 'v6'],
                 ],
             ],
-            $this->getSelectStatementMock()->rowsByGroup('c3', true)
+            (new SelectStatement())->rowsByGroup($executor, 'c3', true)
         );
     }
 
@@ -1897,8 +1900,10 @@ class SelectStatementTest extends TestCase
      */
     public function pagesWithZeroSize(): void
     {
+        $executor = $this->getExecutorMock();
+
         $st = $this->getSelectStatementMockWithGenerator();
-        $pages = $st->pages(0);
+        $pages = $st->pages($executor, 0);
 
         self::assertEmpty(iterator_to_array($pages));
     }
@@ -1908,8 +1913,10 @@ class SelectStatementTest extends TestCase
      */
     public function pagesWithZeroOffset(): void
     {
+        $executor = $this->getExecutorMock();
+
         $st = $this->getSelectStatementMockWithGenerator();
-        $pages = $st->pages(2);
+        $pages = $st->pages($executor, 2);
 
         $i = 0;
         foreach ($pages as $row) {
@@ -1929,8 +1936,10 @@ class SelectStatementTest extends TestCase
      */
     public function pagesWithOffset(): void
     {
+        $executor = $this->getExecutorMock();
+
         $st = $this->getSelectStatementMockWithGenerator();
-        $pages = $st->pages(2, 1);
+        $pages = $st->pages($executor, 2, 1);
 
         foreach ($pages as $row) {
             self::assertSame(['c1' => 'v5', 'c2' => 'v6', 'c3' => 'b'], $row);
@@ -1942,8 +1951,10 @@ class SelectStatementTest extends TestCase
      */
     public function batchesWithZeroSize(): void
     {
+        $executor = $this->getExecutorMock();
+
         $st = $this->getSelectStatementMockWithGenerator();
-        $pages = $st->batches(0);
+        $pages = $st->batches($executor, 0);
 
         self::assertEmpty(iterator_to_array($pages));
     }
@@ -1953,8 +1964,10 @@ class SelectStatementTest extends TestCase
      */
     public function batchesWithZeroOffset(): void
     {
+        $executor = $this->getExecutorMock();
+
         $st = $this->getSelectStatementMockWithGenerator();
-        $pages = $st->batches(2);
+        $pages = $st->batches($executor, 2);
 
         $i = 0;
         foreach ($pages as $row) {
@@ -1983,8 +1996,10 @@ class SelectStatementTest extends TestCase
      */
     public function batchesWithOffset(): void
     {
+        $executor = $this->getExecutorMock();
+
         $st = $this->getSelectStatementMockWithGenerator();
-        $pages = $st->batches(2, 1);
+        $pages = $st->batches($executor, 2, 1);
 
         foreach ($pages as $row) {
             self::assertSame([['c1' => 'v5', 'c2' => 'v6', 'c3' => 'b']], $row);
@@ -2012,11 +2027,14 @@ class SelectStatementTest extends TestCase
         return $st;
     }
 
-    private function getSelectStatementMock(): SelectStatement
+    /**
+     * @psalm-return MockObject&StatementExecutor
+     */
+    private function getSelectStatementExecutorMock()
     {
         $executor = $this->getExecutorMock();
         $executor->method('rows')->willReturn($this->getRowSet());
-        return new SelectStatement($executor);
+        return $executor;
     }
 
     private function getRowSet(): array
@@ -2045,9 +2063,7 @@ class SelectStatementTest extends TestCase
      */
     public function copy(): void
     {
-        $executor = $this->getMockBuilder(StatementExecutor::class)->getMock();
-
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->with('(SELECT * FROM t1)', 'tb')
             ->select('c1, c2')
             ->from('tb1', 't')
@@ -2061,7 +2077,6 @@ class SelectStatementTest extends TestCase
 
         $copy = $st->copy();
 
-        self::assertSame($executor, $copy->getStatementExecutor());
         self::assertSame(
             'WITH tb AS (SELECT * FROM t1) ' .
             'SELECT c1, c2 FROM tb1 t INNER JOIN tb ON tb.id = t.id WHERE c1 > :p1 ' .
@@ -2082,9 +2097,7 @@ class SelectStatementTest extends TestCase
      */
     public function clean(): void
     {
-        $executor = $this->getMockBuilder(StatementExecutor::class)->getMock();
-
-        $st = (new SelectStatement($executor))
+        $st = (new SelectStatement())
             ->with('(SELECT * FROM t1)', 'tb')
             ->select('c1, c2')
             ->from('tb1', 't')
@@ -2098,7 +2111,6 @@ class SelectStatementTest extends TestCase
 
         $st->clean();
 
-        self::assertSame($executor, $st->getStatementExecutor());
         self::assertSame('SELECT *', $st->toSql());
         self::assertEmpty($st->getParams());
     }

--- a/tests/PostgreSql/ValuesStatementTest.php
+++ b/tests/PostgreSql/ValuesStatementTest.php
@@ -8,7 +8,6 @@ use AlephTools\SqlBuilder\PostgreSql\SelectStatement;
 use AlephTools\SqlBuilder\PostgreSql\ValuesStatement;
 use AlephTools\SqlBuilder\Sql\Expression\AbstractExpression;
 use AlephTools\SqlBuilder\Sql\Expression\RawExpression;
-use AlephTools\SqlBuilder\StatementExecutor;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -379,9 +378,7 @@ class ValuesStatementTest extends TestCase
      */
     public function copy(): void
     {
-        $executor = $this->getMockBuilder(StatementExecutor::class)->getMock();
-
-        $st = (new ValuesStatement($executor))
+        $st = (new ValuesStatement())
             ->values([1])
             ->orderBy('column1', 'DESC')
             ->limit(2)
@@ -389,7 +386,6 @@ class ValuesStatementTest extends TestCase
 
         $copy = $st->copy();
 
-        self::assertSame($executor, $copy->getStatementExecutor());
         self::assertSame(
             'VALUES (:p1) ORDER BY column1 DESC LIMIT 2 OFFSET 1',
             $copy->toSql()
@@ -407,9 +403,7 @@ class ValuesStatementTest extends TestCase
      */
     public function clean(): void
     {
-        $executor = $this->getMockBuilder(StatementExecutor::class)->getMock();
-
-        $st = (new ValuesStatement($executor))
+        $st = (new ValuesStatement())
             ->values([1])
             ->orderBy('column1', 'DESC')
             ->limit(2)
@@ -417,7 +411,6 @@ class ValuesStatementTest extends TestCase
 
         $st->clean();
 
-        self::assertSame($executor, $st->getStatementExecutor());
         self::assertSame('VALUES', $st->toSql());
         self::assertEmpty($st->getParams());
     }


### PR DESCRIPTION
Instead of injecting `$db` into a statement as an optional argument:

```php
$count = (new SelectStatement($db))
    ->select('COUNT(*)')
    ->from('users')
    ->scalar();
````

with deferred validation in `scalar` method it is more useful to pass the executor into an active method:

```php
$count = (new SelectStatement())
    ->select('COUNT(*)')
    ->from('users')
    ->scalar($db);
````

It allows us to remove `$this->db` property validation and allows clients to execute one statement with multiple connections.